### PR TITLE
spawn serversock listen

### DIFF
--- a/hubpackage/src/bridge.lua
+++ b/hubpackage/src/bridge.lua
@@ -253,11 +253,11 @@ local function start_bridge_server(driver)
     bridge_thread = Thread(driver, "bridge thread")
   end
   if handler_id then
-    bridge_thread.unregister_channel_handler(handler_id)
+    bridge_thread.unregister_socket(handler_id)
     
   end
   
-  handler_id = bridge_thread.register_channel_handler(serversock, watch_socket)
+  handler_id = bridge_thread.register_socket(serversock, watch_socket)
 
 end
 
@@ -265,7 +265,7 @@ end
 local function shutdown(driver)
   log.debug ('Shutting down Bridge server')
   if handler_id and bridge_thread then
-    bridge_thread.unregister_channel_handler(handler_id)
+    bridge_thread.unregister_socket(handler_id)
   end
   if bridge_thread then
     bridge_thread:close()

--- a/hubpackage/src/bridge.lua
+++ b/hubpackage/src/bridge.lua
@@ -254,6 +254,7 @@ local function start_bridge_server(driver)
   end
   if handler_id then
     bridge_thread.unregister_channel_handler(handler_id)
+    
   end
   
   handler_id = bridge_thread.register_channel_handler(serversock, watch_socket)


### PR DESCRIPTION
This PR updates the driver to no longer attempt to accept incoming connections on the driver's main thread. This implementation is somewhat simple as it doesn't use the `Thread` class provided by the platform but instead just uses `cosock.spawn` and loops forever in the provided function. 

With these changes I have been able to run this driver on my v3 through a number of re-installs w/o any issues. You are welcome to use these changes as is or close this PR if you'd rather do something else to solve this problem. I mostly wanted to communicate _some_ solution to your problem. I expect we will have further discussion internally regarding how we can ease the confusion about the `register_channel_handler` and `call_with_delay/on_schedule` methods on `Driver`